### PR TITLE
Fix code style and clean up node_db.py

### DIFF
--- a/daemons/node_db.py
+++ b/daemons/node_db.py
@@ -1,96 +1,156 @@
-#!/usr/bin/python
-#
-# A utility called to update the (currently, in-file) database of nodes/ip addresses
-# This is a command-line utility over the routines in node_db_lib.py.  
-#
-# usage: node_db.py add/delete <name> <ip_address>
-# all parameters are positional and are required
-#
-# This is very much an MVP piece of code -- it will need to be replaced with a SQL DB fairly soon.
-#
+"""
+node_db.py
 
-import sys
-from node_db_lib import Sqllite3DB
-from functools import reduce
+Update the (currently, in-file) database of nodes/IP addresses.
+
+This is a command-line utility over the routines in node_db_lib.py.
+
+Usage:
+    node_db.py add/delete <name> <ip_address>
+
+All parameters are positional and are required.
+
+NOTE: This is very much an MVP piece of code -- it will need to be
+      replaced with a SQL DB fairly soon.
+"""
+
+import node_db_lib
+import argparse
+import socket
 
 
-#
-# Check that an_IP_address is a valid IPv4 address. 
-# an_IP_address: a string to be checked for being a valid IPv4 address
-# Returns: True if it is, False otherwise
-# TODO: check to make sure it's routable.
-#
+def is_public_IPv4_address(string):
+    """
+    <Purpose>
+      Check if `string` contains a public IPv4 address.
 
-def check_ip(an_IP_address):
-    IP_array = an_IP_address.split('.')
-    if (len(IP_array) != 4): return False
-    for i in range(4):
-        try:
-            val = int(IP_array[i])
-            if val < 0 or val > 255: return False
-        except ValueError:
+    <Argument>
+      string: The string to check
+
+    <Exceptions>, <Side Effects>
+      None
+
+    <Returns>
+      True if `string` contains a public IPv4 address, False otherwise.
+    """
+    try:
+        # Does string have four octets?
+        first_octet, second_octet, _, _ = string.split(".")
+        # Are the numbers in the proper range?
+        socket.inet_aton(string)
+        # Check these private/nonroutable IPv4 address ranges:
+        #   RFC1918: 10/8, 172.16/12, 192.168/16,
+        #   RFC1122 multicast 224/28
+        #   RFC6598 CGNAT: 100.64/10
+        if (first_octet == "10" or
+                (first_octet == "172" and 16 <= int(second_octet) < 32) or
+                (first_octet == "192" and second_octet == "168") or
+                (224 <= int(first_octet) < 240) or
+                (first_octet == "100" and 64 <= int(second_octet) < 128)):
+            return False
+        else:
+            return True
+    except (OSError, # inet_aton couldn't parse it
+             AttributeError, # argument had no split method
+             ValueError, # wrong number of values to unpack on split
+             ):
+        return False
+
+
+
+def is_RFC1035_label(name):
+    """
+    <Purpose>
+      Check if a name is a well-formed RFC 1035 label.
+      Labels are strings, start with a letter, do not end in a hyphen,
+      contain only letters, digits, and hyphens otherwise, are at most
+      63 characters long and not empty.
+      Note that FQDNs are invalid by this definition as they contain dots!
+
+    <Argument>
+      name: The name to check
+
+    <Exceptions>, <Side Effects>
+      None
+
+    <Returns>
+      True if name is a well-formed RFC 1035 label, False otherwise.
+    """
+    if type(name) is not str:
+        return False
+
+    # Check length, first and last characters
+    if not (0 < len(name) <= 63):
+        return False
+    if not name[0].isalpha() or name.endswith("-"):
+        return False
+
+    # Check for allowed characters throughout
+    for char in name:
+        if not (char.isdigit() or char.isalpha() or char == "-"):
             return False
     return True
 
-#
-# Check that a_name is a valid host name for a domain name.  Note that only the host
-# name should be given, not the FQDN: 'www' is valid, 'www.yahoo.com' is not. 
-# a_name: a string to be checked for being a valid host name
-# Returns: True if it is, False otherwise
-# Rules: valid characters are alphanumerics, hyphen, the name cannot begin or end with a hyphen,
-#        and must be of length <= 63, and can't be empty
-#
-def ok_name(a_name):
-    if (len(a_name) > 63 or len(a_name) == 0): return False
-    result = reduce(lambda x, y: x and (y.isdigit() or y.isalpha() or (y == '-')), a_name, True)
-    return result and a_name[0] != '-' and a_name[-1] != '-'
 
-#
-# Print a usage message and exit.  This is called by check_args if there are
-# any problems with the command line.
-# Side effect: exits with an error
-# 
-def print_usage_and_exit():
-    print 'Usage: node_db.py add/delete host_name ip_address'
-    exit(1)
 
-#
-# Check the command line arguments for validity -- that there are three arguments,
-# 1. The first is add or delete
-# 2. The second is a valis host_name (see ok_name)
-# 3. The third is a valid ip address (see check_IP)
-# Returns: (command, host_name, address) as a triple
-# Side Effects: exits with an error message if there is an error
-# 
+def handle_command_line_args():
+    """
+    <Purpose>
+      Handle the tool's command line args (via `argparse`).
 
-def check_args():
-    if (len(sys.argv) != 4): print_usage_and_exit()
-    command = sys.argv[1]
-    host_name = sys.argv[2]
-    address = sys.argv[3]
-    if (command != 'add' and command != 'delete'): print_usage_and_exit()
-    if (not ok_name(host_name)): print_usage_and_exit()
-    if (not check_ip(address)): print_usage_and_exit()
-    return (command, host_name, address)
+    <Arguments, Exceptions>
+      None
 
-#
-# Main routine.
-# 1. Get the command, host_name, and address from the command line
-# 2. Execute the add or delete command
-# 3. Print the DB
-#
+    <Side Effects>
+      If the arguments do not conform to the expected format, print
+      usage information and exit.
 
-if __name__ == '__main__':
-    db = Sqllite3DB()
-    (command, host_name, address) = check_args()
-    if (command == 'add'):
+    <Returns>
+      The command, host label, and IPv4 address
+    """
+    parser = argparse.ArgumentParser(description="Update node/IP database")
+    parser.add_argument("command", choices=["add", "delete"],
+            help="Action to perform on the database entry")
+    parser.add_argument("host_label", help="Name of host, excluding its domain suffix")
+    parser.add_argument("ipv4", help="Public IPv4 address of host")
+    args = parser.parse_args()
+
+    # Check argument contents, print usage on error
+    if (not is_public_IPv4_address(args.ipv4) or
+            not is_RFC1035_label(args.host_label)):
+        parser.parse_args(["-h"])
+
+    return args.command, args.host_label, args.ipv4
+
+
+
+def main():
+    """
+    <Purpose>
+      Grab the command line args and execute the add or delete command.
+      Afterwards, print the database contents.
+
+    <Arguments>, <Exceptions>
+      None
+
+    <Side Effects>
+      Update the database according to the command-line args.
+
+    <Returns>
+      None
+    """
+    command, host_label, address = handle_command_line_args()
+
+    db = node_db_lib.Sqllite3DB()
+    if command == 'add':
         db.add_entry(host_list, host_name, address)
-    else:
+    elif command == 'delete':
         db.delete_entry(host_list, host_name, address)
     host_list = db.read_db()
-    print host_list
-    
+    print(host_list)
 
 
-        
+
+if __name__ == '__main__':
+    main()
 


### PR DESCRIPTION
Changes from top to bottom:
* Remove shebang as the file is not `chmod`ded to allow execution.
* Update and clarify top-level docstring.
* Use module-level imports throughout. (`from X import Y` saves only
  so many `X`s to type, but clarity suffers.)
* Rename `check_ip` to `is_public_IPv4_address`,
  - Add docstring
  - Use `socket.inet_aton` for basic numeric check,
  - Add check for private/multicast addresses.
* Rename `ok_name` to `is_RFC1035_label` (because this is what it seems
  we are checking),
  - Add docstring,
  - Remove `functools.reduce` and `lambda` for clarity,
  - Add additional check for leading alpha (but not hyphen nor digit)
* Replace `check_args` and `print_usage_and_exit` with a proper argument
  parser from the `argparse` module
* Add `handle_command_line_args` function with `choices`, help strings, etc.
* Add `main` function for database connection and command handling.