### PR TITLE
Existing DNS Records management for the nodes 

### DIFF
--- a/pkg/node/infrastructure/join.go
+++ b/pkg/node/infrastructure/join.go
@@ -153,25 +153,17 @@ func getHosts(client *namecheap.Client) namecheap.DomainDNSGetHostsResult {
 func SetHostname(client *namecheap.Client, hostRecord namecheap.DomainDNSHost) (bool, string) {
 	hostList := getHosts(client)
 	exist := false
-	for _, host := range hostList.Hosts {
+	for key, host := range hostList.Hosts {
 		if host.Name == hostRecord.Name || host.Address == hostRecord.Address {
+			// If the record exist then update it, overwrite it with new name and address
+			hostList.Hosts[key] = hostRecord
+			log.Printf("Update existing host: %s - %s \n Hostname  and ip address changed to: %s - %s", host.Name, host.Address, hostRecord.Name, hostRecord.Address)
 			exist = true
 			break
 		}
 	}
-
-	//if the record exist then update it, overwrite it with new name and address.
-	if exist {
-		for i, v := range hostList.Hosts {
-			if v.Name == hostRecord.Name || v.Address == hostRecord.Address {
-				hostList.Hosts[i] = hostRecord
-				break
-			}
-		}
-		log.Printf("UPDATE existing host: %s - %s \n Hostname  and ip address changed to: %s - %s", v.Name, v.Address, hostRecord.Name, hostRecord.Address)
-
-	} else {
-		//in case the record is new, it is appended to the list of existing records
+	// In case the record is new, it is appended to the list of existing records
+	if !exist {
 		hostList.Hosts = append(hostList.Hosts, hostRecord)
 	}
 	setResponse, err := client.DomainDNSSetHosts("edge-net", "io", hostList.Hosts)

--- a/pkg/node/infrastructure/join.go
+++ b/pkg/node/infrastructure/join.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/util/cert"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
+
 	//nodebootstraptokenphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node"
 
 	kubeadmtypes "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
@@ -163,18 +164,15 @@ func SetHostname(client *namecheap.Client, hostRecord namecheap.DomainDNSHost) (
 	if exist {
 		for i, v := range hostList.Hosts {
 			if v.Name == hostRecord.Name || v.Address == hostRecord.Address {
-				hostsList.Hosts[i] = hostRecord
+				hostList.Hosts[i] = hostRecord
 				break
 			}
 		}
-		log.Printf("UPDATE existing host: Hostname  and ip address changed to: %s - %s", hostRecord.Name, hostRecord.Address)
+		log.Printf("UPDATE existing host: %s - %s \n Hostname  and ip address changed to: %s - %s", v.Name, v.Address, hostRecord.Name, hostRecord.Address)
 
-	}
-
-	//in case the record is new, it is appended to the list of existing records
-	if !exist {
+	} else {
+		//in case the record is new, it is appended to the list of existing records
 		hostList.Hosts = append(hostList.Hosts, hostRecord)
-
 	}
 	setResponse, err := client.DomainDNSSetHosts("edge-net", "io", hostList.Hosts)
 	if err != nil {

--- a/pkg/node/infrastructure/join.go
+++ b/pkg/node/infrastructure/join.go
@@ -159,12 +159,23 @@ func SetHostname(client *namecheap.Client, hostRecord namecheap.DomainDNSHost) (
 		}
 	}
 
+	//if the record exist then update it, overwrite it with new name and address.
 	if exist {
-		log.Printf("Hostname or ip address already exists: %s - %s", hostRecord.Name, hostRecord.Address)
-		return false, "exist"
+		for i, v := range hostList.Hosts {
+			if v.Name == hostRecord.Name || v.Address == hostRecord.Address {
+				hostsList.Hosts[i] = hostRecord
+				break
+			}
+		}
+		log.Printf("UPDATE existing host: Hostname  and ip address changed to: %s - %s", hostRecord.Name, hostRecord.Address)
+
 	}
 
-	hostList.Hosts = append(hostList.Hosts, hostRecord)
+	//in case the record is new, it is appended to the list of existing records
+	if !exist {
+		hostList.Hosts = append(hostList.Hosts, hostRecord)
+
+	}
 	setResponse, err := client.DomainDNSSetHosts("edge-net", "io", hostList.Hosts)
 	if err != nil {
 		log.Println(err.Error())


### PR DESCRIPTION
I suggest changes to the nodecontribution function. Node contribution implies DNS records management. A DNS Record is defined by a hostname and an IP address and both these attributes are exclusively allocated to a host among the list of node's hosts. From now on, any matching in either IP address or host name yields an update of an existing host with a new coming DNS record.