### PR TITLE
Update control plane node SSH key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # config files
 configs/**
 !configs/id_rsa.pub
+!configs/id_edgenet_2021.pub
 !configs/*_template.yaml
 !configs/user-files
 !configs/user-files/**
@@ -44,3 +45,6 @@ hack
 
 # Ignore OS X metadata files
 ._*
+
+# IDEA
+.idea/

--- a/configs/id_edgenet_2021.pub
+++ b/configs/id_edgenet_2021.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKjtRjXehOq2CkwI3dsDeec5mC8KxykSoSeywES4nrw9 edgenet.planet-lab.eu (2021)

--- a/pkg/controller/core/v1alpha/nodecontribution/handler.go
+++ b/pkg/controller/core/v1alpha/nodecontribution/handler.go
@@ -61,7 +61,7 @@ func (t *Handler) Init(kubernetes kubernetes.Interface, edgenet versioned.Interf
 	t.edgenetClientset = edgenet
 
 	// Get the SSH Public Key of the headnode
-	key, err := ioutil.ReadFile("../../.ssh/id_rsa")
+	key, err := ioutil.ReadFile("../../.ssh/id_edgenet_2021")
 	if err != nil {
 		log.Println(err.Error())
 		panic(err.Error())


### PR DESCRIPTION
Replace the RSA key with an ed25519 key, to accomodate newer Linux distributions:
https://dev.to/bowmanjd/upgrade-ssh-client-keys-and-remote-servers-after-fedora-33-s-new-crypto-policy-47ag