### PR TITLE
 Fedmanctl for automating cluster federation command rename

### DIFF
--- a/cmd/fedmanctl/fedmanctl.go
+++ b/cmd/fedmanctl/fedmanctl.go
@@ -1,0 +1,7 @@
+package main
+
+import fedmanctl "github.com/EdgeNet-project/edgenet/pkg/fedmanctl/cmd"
+
+func main() {
+	fedmanctl.Execute()
+}

--- a/go.mod
+++ b/go.mod
@@ -24,19 +24,12 @@ require (
 	sigs.k8s.io/cluster-api v0.3.10
 )
 
-require k8s.io/code-generator v0.21.2
+require github.com/spf13/cobra v1.1.1
 
 require (
-	github.com/PuerkitoBio/purell v1.1.1 // indirect
-	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/emicklei/go-restful v2.10.0+incompatible // indirect
 	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
 	github.com/go-logr/logr v0.4.0 // indirect
-	github.com/go-openapi/jsonpointer v0.19.3 // indirect
-	github.com/go-openapi/jsonreference v0.19.3 // indirect
-	github.com/go-openapi/spec v0.19.5 // indirect
-	github.com/go-openapi/swag v0.19.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -45,30 +38,27 @@ require (
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/native v0.0.0-20200817173448-b6b71def0850 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect
-	github.com/mailru/easyjson v0.7.0 // indirect
 	github.com/mdlayher/genetlink v1.0.0 // indirect
 	github.com/mdlayher/netlink v1.4.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 // indirect
-	golang.org/x/tools v0.1.12 // indirect
 	golang.zx2c4.com/wireguard v0.0.0-20210427022245-097af6e1351b // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 // indirect
 	k8s.io/kube-openapi v0.0.0-20210305164622-f622666832c1 // indirect
 	k8s.io/utils v0.0.0-20210527160623-6fdb442a123b // indirect
 	sigs.k8s.io/controller-runtime v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,10 +47,8 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
-github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -126,8 +124,6 @@ github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkg
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful v2.10.0+incompatible h1:l6Soi8WCOOVAeCo4W98iBFC6Og7/X8bpRt51oNLZ2C8=
-github.com/emicklei/go-restful v2.10.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
@@ -174,13 +170,11 @@ github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
-github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.18.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
-github.com/go-openapi/jsonreference v0.19.3 h1:5cxNfTy0UVC3X8JL5ymxzyoUZmo8iZb+jeTWn7tUa8o=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
 github.com/go-openapi/loads v0.17.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.18.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
@@ -195,7 +189,6 @@ github.com/go-openapi/spec v0.17.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsd
 github.com/go-openapi/spec v0.18.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcsZsD5zxMY=
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
-github.com/go-openapi/spec v0.19.5 h1:Xm0Ao53uqnk9QE/LlYV5DEU09UAgpliA85QoT9LzqPw=
 github.com/go-openapi/spec v0.19.5/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
@@ -205,7 +198,6 @@ github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dp
 github.com/go-openapi/swag v0.17.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.18.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
-github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
@@ -329,6 +321,7 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
@@ -390,7 +383,6 @@ github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -538,6 +530,7 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -649,8 +642,6 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -852,8 +843,6 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
-golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -991,14 +980,12 @@ k8s.io/cluster-bootstrap v0.17.9/go.mod h1:Q6nXn/sqVfMvT1VIJVPxFboYAoqH06PCjZnaY
 k8s.io/cluster-bootstrap v0.19.2 h1:6/LI5EnKCcB0QiDKIsTxoCOdKZtsSwr8Xm/tEhiMv78=
 k8s.io/cluster-bootstrap v0.19.2/go.mod h1:bzngsppPfdt9vAHUnDIEoMNsxD2b6XArVVH/W9PDDFk=
 k8s.io/code-generator v0.17.9/go.mod h1:iiHz51+oTx+Z9D0vB3CH3O4HDDPWrvZyUgUYaIE9h9M=
-k8s.io/code-generator v0.21.2 h1:EyHysEtLHTsNMoace0b3Yec9feD0qkV+5RZRoeSh+sc=
 k8s.io/code-generator v0.21.2/go.mod h1:8mXJDCB7HcRo1xiEQstcguZkbxZaqeUOrO9SsicWs3U=
 k8s.io/component-base v0.17.9/go.mod h1:Wg22ePDK0mfTa+bEFgZHGwr0h40lXnYy6D7D+f7itFk=
 k8s.io/component-base v0.21.2/go.mod h1:9lvmIThzdlrJj5Hp8Z/TOgIkdfsNARQ1pT+3PByuiuc=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 h1:Uusb3oh8XcdzDF/ndlI4ToKTYVlkCSJP39SRY2mfRAw=
 k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/pkg/fedmanctl/cmd/manager.go
+++ b/pkg/fedmanctl/cmd/manager.go
@@ -18,7 +18,7 @@ var managerCmd = &cobra.Command{
 
 var managerFederateCmd = &cobra.Command{
 	Use:   "federate <token> <namespace>",
-	Short: "Federate a worker cluster with the generated token.",
+	Short: "Federate a workload cluster with the generated token and a namespace.",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		f, err := fedmanctl.NewFedmanctl(kubeconfig, context, true)
@@ -33,13 +33,13 @@ var managerFederateCmd = &cobra.Command{
 			panic(err.Error())
 		}
 
-		fmt.Println("Linked worker cluster")
+		fmt.Println("Federated workload cluster")
 	},
 }
 
 var managerSeparateCmd = &cobra.Command{
 	Use:   "separate <uid> <namespace>",
-	Short: "Separate a worker cluster with the uid.",
+	Short: "Separate a workload cluster with the uid and namespace.",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		f, err := fedmanctl.NewFedmanctl(kubeconfig, context, true)
@@ -59,7 +59,7 @@ var managerSeparateCmd = &cobra.Command{
 			panic(err.Error())
 		}
 
-		fmt.Println("Unlinked worker cluster")
+		fmt.Println("Sperated the workload cluster")
 	},
 }
 
@@ -80,7 +80,7 @@ var managerListCmd = &cobra.Command{
 		}
 
 		if len(clusters) == 0 {
-			fmt.Println("no worker clusters available")
+			fmt.Println("No workload clusters available")
 		} else {
 			w := tabwriter.NewWriter(os.Stdout, 20, 20, 1, ' ', 0)
 

--- a/pkg/fedmanctl/cmd/manager.go
+++ b/pkg/fedmanctl/cmd/manager.go
@@ -37,9 +37,9 @@ var managerFederateCmd = &cobra.Command{
 	},
 }
 
-var managerUnfederateCmd = &cobra.Command{
-	Use:   "unfederate <uid> <namespace>",
-	Short: "Unfederate a worker cluster with the uid.",
+var managerSeparateCmd = &cobra.Command{
+	Use:   "separate <uid> <namespace>",
+	Short: "Separate a worker cluster with the uid.",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		f, err := fedmanctl.NewFedmanctl(kubeconfig, context, true)
@@ -53,7 +53,7 @@ var managerUnfederateCmd = &cobra.Command{
 		// If user inputs cluster-XXX format, convert it to normal uid
 		clusterUID = strings.Replace(clusterUID, "cluster-", "", 1)
 
-		err = f.UnfederateWorkloadCluster(clusterUID, args[1])
+		err = f.SeparateWorkloadCluster(clusterUID, args[1])
 
 		if err != nil {
 			panic(err.Error())
@@ -97,6 +97,6 @@ var managerListCmd = &cobra.Command{
 
 func init() {
 	managerCmd.AddCommand(managerFederateCmd)
-	managerCmd.AddCommand(managerUnfederateCmd)
+	managerCmd.AddCommand(managerSeparateCmd)
 	managerCmd.AddCommand(managerListCmd)
 }

--- a/pkg/fedmanctl/cmd/manager.go
+++ b/pkg/fedmanctl/cmd/manager.go
@@ -1,0 +1,102 @@
+package fedmanctl
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/EdgeNet-project/edgenet/pkg/fedmanctl"
+	"github.com/spf13/cobra"
+)
+
+var managerCmd = &cobra.Command{
+	Use:     "manager",
+	Aliases: []string{"m"},
+	Short:   "Manage manager clusters",
+}
+
+var managerFederateCmd = &cobra.Command{
+	Use:   "federate <token> <namespace>",
+	Short: "Federate a worker cluster with the generated token.",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		f, err := fedmanctl.NewFedmanctl(kubeconfig, context, true)
+
+		if err != nil {
+			panic(err.Error())
+		}
+
+		err = f.FederateWorkloadCluster(args[0], args[1])
+
+		if err != nil {
+			panic(err.Error())
+		}
+
+		fmt.Println("Linked worker cluster")
+	},
+}
+
+var managerUnfederateCmd = &cobra.Command{
+	Use:   "unfederate <uid> <namespace>",
+	Short: "Unfederate a worker cluster with the uid.",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		f, err := fedmanctl.NewFedmanctl(kubeconfig, context, true)
+
+		if err != nil {
+			panic(err.Error())
+		}
+
+		clusterUID := args[0]
+
+		// If user inputs cluster-XXX format, convert it to normal uid
+		clusterUID = strings.Replace(clusterUID, "cluster-", "", 1)
+
+		err = f.UnfederateWorkloadCluster(clusterUID, args[1])
+
+		if err != nil {
+			panic(err.Error())
+		}
+
+		fmt.Println("Unlinked worker cluster")
+	},
+}
+
+var managerListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all of the federated clusters.",
+	Run: func(cmd *cobra.Command, args []string) {
+		f, err := fedmanctl.NewFedmanctl(kubeconfig, context, true)
+
+		if err != nil {
+			panic(err.Error())
+		}
+
+		clusters, err := f.ListWorkloadClusters()
+
+		if err != nil {
+			panic(err.Error())
+		}
+
+		if len(clusters) == 0 {
+			fmt.Println("no worker clusters available")
+		} else {
+			w := tabwriter.NewWriter(os.Stdout, 20, 20, 1, ' ', 0)
+
+			// Display these properties
+			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", "CLUSTER NAME", "CLUSTER NAMESPACE", "VISIBILITY", "ENABLED", "STATE")
+
+			for _, cluster := range clusters {
+				fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", cluster.ObjectMeta.Name, cluster.ObjectMeta.Namespace, cluster.Spec.Visibility, cluster.Spec.Enabled, cluster.Status.State)
+			}
+			w.Flush()
+		}
+	},
+}
+
+func init() {
+	managerCmd.AddCommand(managerFederateCmd)
+	managerCmd.AddCommand(managerUnfederateCmd)
+	managerCmd.AddCommand(managerListCmd)
+}

--- a/pkg/fedmanctl/cmd/root.go
+++ b/pkg/fedmanctl/cmd/root.go
@@ -1,0 +1,39 @@
+package fedmanctl
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// kubeconfig file path
+	kubeconfig string
+
+	// context on the kubeconfig file
+	context string
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "fedmanctl",
+	Short: "fedmanctl federate Kubernetes clusters",
+	Long: `fedmanctl is a simple CLI for federating Kubernetes clusters using EdgeNet features. For more info 
+please visit the EdgeNet GitHub page available https://github.com/edgenet-project/edgenet`,
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "Kubeconfig file to be used")
+	rootCmd.PersistentFlags().StringVar(&context, "context", "", "The context specified in the kubeconfig file")
+
+	rootCmd.AddCommand(workloadCmd)
+	rootCmd.AddCommand(managerCmd)
+	rootCmd.AddCommand(versionCmd)
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "An error occured while executing fedmanctl: '%s'", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/fedmanctl/cmd/version.go
+++ b/pkg/fedmanctl/cmd/version.go
@@ -1,0 +1,22 @@
+package fedmanctl
+
+import (
+	"fmt"
+
+	"github.com/EdgeNet-project/edgenet/pkg/fedmanctl"
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "print the version of the fedmanctl",
+	Run: func(cmd *cobra.Command, args []string) {
+		f, err := fedmanctl.NewFedmanctl(kubeconfig, context, false)
+
+		if err != nil {
+			panic(err.Error())
+		}
+
+		fmt.Printf("%v\n", f.Version())
+	},
+}

--- a/pkg/fedmanctl/cmd/workload.go
+++ b/pkg/fedmanctl/cmd/workload.go
@@ -1,0 +1,114 @@
+package fedmanctl
+
+import (
+	"fmt"
+
+	"github.com/EdgeNet-project/edgenet/pkg/fedmanctl"
+	"github.com/spf13/cobra"
+)
+
+var workloadCmd = &cobra.Command{
+	Use:     "workload",
+	Aliases: []string{"w"},
+	Short:   "Manage workload clusters",
+}
+
+var workloadInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize the cluster as the workload cluster. Configure such that, it can receive and send workloads.",
+	Run: func(cmd *cobra.Command, args []string) {
+		f, err := fedmanctl.NewFedmanctl(kubeconfig, context, true)
+
+		if err != nil {
+			panic(err.Error())
+		}
+
+		err = f.InitWorkloadCluster()
+
+		if err != nil {
+			panic(err.Error())
+		}
+
+		fmt.Println("Initialized workload cluster")
+	},
+}
+
+var workloadResetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Reset the configuration of the cluster as a workload cluster.",
+	Run: func(cmd *cobra.Command, args []string) {
+		f, err := fedmanctl.NewFedmanctl(kubeconfig, context, true)
+
+		if err != nil {
+			panic(err.Error())
+		}
+
+		err = f.ResetWorkloadCluster()
+
+		if err != nil {
+			panic(err.Error())
+		}
+
+		fmt.Println("Reset workload cluster")
+	},
+}
+
+var workloadTokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Generate the token to be fed to the manager cluster. Geo tags can be overwritten.",
+	Run: func(cmd *cobra.Command, args []string) {
+		silent, _ := cmd.Flags().GetBool("silent")
+		debug, _ := cmd.Flags().GetBool("debug")
+
+		f, err := fedmanctl.NewFedmanctl(kubeconfig, context, silent)
+
+		if err != nil {
+			panic(err.Error())
+		}
+
+		city, _ := cmd.Flags().GetString("city")
+		country, _ := cmd.Flags().GetString("country")
+
+		ip, _ := cmd.Flags().GetString("ip")
+		port, _ := cmd.Flags().GetString("port")
+
+		// more types of labels can be added here
+		labels := map[string]string{
+			"edge-net.io/city":    city,
+			"edge-net.io/country": country,
+		}
+
+		visibility, _ := cmd.Flags().GetString("visibility")
+
+		token, err := f.GenerateWorkloadClusterToken(ip, port, visibility, debug, labels)
+
+		if err != nil {
+			panic(err.Error())
+		}
+
+		if !silent {
+			fmt.Println("Token generated use the following command to link the workload cluster with your manager cluster.")
+			fmt.Println("")
+			fmt.Printf("fedmanctl manager link %v\n", token)
+		} else {
+			fmt.Printf("%v\n", token)
+		}
+
+	},
+}
+
+func init() {
+	workloadTokenCmd.Flags().Bool("silent", false, "Only print the token")
+	workloadTokenCmd.Flags().Bool("debug", false, "Print the token in json format")
+
+	workloadTokenCmd.Flags().String("visibility", "Public", "Visibility of the cluster, Public or Private")
+	workloadTokenCmd.Flags().String("ip", "", "IP address of the kube-apiserver")
+	workloadTokenCmd.Flags().String("port", "", "Port of the kube-apiserver")
+
+	workloadTokenCmd.Flags().String("city", "", "Override the city label of the cluster")
+	workloadTokenCmd.Flags().String("country", "", "Override the country label of the cluster")
+
+	workloadCmd.AddCommand(workloadInitCmd)
+	workloadCmd.AddCommand(workloadResetCmd)
+	workloadCmd.AddCommand(workloadTokenCmd)
+}

--- a/pkg/fedmanctl/fedmanctl.go
+++ b/pkg/fedmanctl/fedmanctl.go
@@ -1,0 +1,395 @@
+package fedmanctl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	federationv1alpha1 "github.com/EdgeNet-project/edgenet/pkg/apis/federation/v1alpha1"
+	"github.com/EdgeNet-project/edgenet/pkg/bootstrap"
+	"github.com/EdgeNet-project/edgenet/pkg/generated/clientset/versioned"
+	rbacv1 "k8s.io/api/rbac/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Fedmanctl interface {
+	// Getter for EdgeNet clientset
+	GetEdgeNetClientset() *versioned.Clientset
+
+	// Getter for Kubernetes clientset
+	GetKubeClientset() *kubernetes.Clientset
+
+	// Initialize the given cluster as the worker cluster. Do not generate a token.
+	InitWorkloadCluster() error
+
+	// Delete and remove all the configuration of the worker cluster.
+	ResetWorkloadCluster() error
+
+	// Generate the token of the worker cluster with the given labels
+	GenerateWorkloadClusterToken(clusterIP, clusterPort, visibility string, debug bool, labels map[string]string) (string, error)
+
+	// Link the worker cluster to the manager cluster. Configures the manager cluster by the token. Called by the manager context.
+	FederateWorkloadCluster(token, namespace string) error
+
+	// Unlinks the worker cluster from manager cluster. Called by the manager context.
+	UnfederateWorkloadCluster(uid, namespace string) error
+
+	// List the worker cluster objects
+	ListWorkloadClusters() ([]federationv1alpha1.Cluster, error)
+
+	Version() string
+}
+
+type fedmanctl struct {
+	Fedmanctl
+	edgenetClientset *versioned.Clientset
+	kubeClientset    *kubernetes.Clientset
+	clusterIP        string
+	clusterPort      string
+}
+
+// Create a new interface for fedmanctl
+func NewFedmanctl(kubeconfig, context string, silent bool) (Fedmanctl, error) {
+	var config *rest.Config
+	var err error
+
+	if kubeconfig == "" {
+		kubeconfig = os.Getenv("KUBECONFIG")
+	}
+
+	// Get the specified context if context variable is a non-empty string
+	if context != "" {
+		config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+			&clientcmd.ConfigOverrides{
+				CurrentContext: context,
+			}).ClientConfig()
+
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	edgenetclientset, err := bootstrap.CreateEdgeNetClientset(config)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeclientset, err := bootstrap.CreateKubeClientset(config)
+	if err != nil {
+		return nil, err
+	}
+
+	hostport := config.Host
+
+	if strings.Contains(config.Host, "//") {
+		if !silent {
+			fmt.Println("Warning: The token generated contains a url instead of an ip:port. This might mean there is a proxy and federation might not work, override the ip and port using --ip and --port options.")
+			fmt.Println("")
+		}
+		hostport = strings.Split(hostport, "//")[1]
+	}
+
+	// Split it like that so it also supports ipv6 addresses
+	host, port, err := net.SplitHostPort(hostport)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return fedmanctl{
+		edgenetClientset: edgenetclientset,
+		kubeClientset:    kubeclientset,
+		clusterIP:        host,
+		clusterPort:      port,
+	}, nil
+}
+
+// Getter for EdgeNet clientset
+func (f fedmanctl) GetEdgeNetClientset() *versioned.Clientset {
+	return f.edgenetClientset
+}
+
+// Getter for Kubernetes clientset
+func (f fedmanctl) GetKubeClientset() *kubernetes.Clientset {
+	return f.kubeClientset
+}
+
+// Initialize the given cluster as the worker cluster. Do not generate a token.
+func (f fedmanctl) InitWorkloadCluster() error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "fedmanager",
+		},
+	}
+	_, err := f.GetKubeClientset().CoreV1().ServiceAccounts("edgenet").Create(context.TODO(), sa, v1.CreateOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	s := &corev1.Secret{
+		Type: "kubernetes.io/service-account-token",
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "fedmanager",
+			Namespace: "edgenet",
+			Annotations: map[string]string{
+				"kubernetes.io/service-account.name": "fedmanager",
+			},
+		},
+	}
+
+	_, err = f.GetKubeClientset().CoreV1().Secrets("edgenet").Create(context.TODO(), s, v1.CreateOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "edgenet:fedmanager",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Namespace: "edgenet",
+				Name:      "fedmanager",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     "edgenet:federation:remotecluster",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+
+	_, err = f.GetKubeClientset().RbacV1().ClusterRoleBindings().Create(context.TODO(), crb, v1.CreateOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete and remove all the configuration of the worker cluster.
+func (f fedmanctl) ResetWorkloadCluster() error {
+	f.GetKubeClientset().RbacV1().ClusterRoleBindings().Delete(context.TODO(), "edgenet:fedmanager", v1.DeleteOptions{})
+	f.GetKubeClientset().CoreV1().ServiceAccounts("edgenet").Delete(context.TODO(), "fedmanager", v1.DeleteOptions{})
+	f.GetKubeClientset().CoreV1().Secrets("edgenet").Delete(context.TODO(), "fedmanager", v1.DeleteOptions{})
+	return nil
+}
+
+// Generate the token of the worker cluster with the given labels
+func (f fedmanctl) GenerateWorkloadClusterToken(clusterIP, clusterPort, visibility string, debug bool, labels map[string]string) (string, error) {
+	clusterUID, err := f.getClusterUID()
+
+	if err != nil {
+		return "", err
+	}
+
+	secret, err := f.getSecret()
+
+	if err != nil {
+		return "", err
+	}
+
+	requiredDataFieldList := []string{"ca.crt", "token", "namespace"}
+	// Check for specific fields that we require from the secret
+	for _, field := range requiredDataFieldList {
+		if _, ok := secret.Data[field]; !ok {
+			return "", errors.New("worker cluster secret does not have required data, reset the worker or wait until controllers create secret certificate")
+		}
+	}
+
+	nClusterIP := f.clusterIP
+	nClusterPort := f.clusterPort
+
+	if clusterIP != "" {
+		nClusterIP = clusterIP
+	}
+
+	if clusterPort != "" {
+		nClusterPort = clusterPort
+	}
+
+	// base64 encoded secrets except the cluster uid
+	token := &WorkloadClusterInfo{
+		CACertificate: string(secret.Data["ca.crt"]),
+		Namespace:     string(secret.Data["namespace"]),
+		Token:         string(secret.Data["token"]),
+		UID:           clusterUID,
+		ClusterIP:     nClusterIP,
+		ClusterPort:   nClusterPort,
+		Visibility:    visibility,
+		Labels:        labels,
+	}
+
+	if debug {
+		b, err := json.Marshal(token)
+
+		if err != nil {
+			return "", err
+		}
+
+		return string(b), nil
+	}
+
+	return TokenizeWorkloadClusterInfo(token)
+}
+
+// Link the worker cluster to the manager cluster. Configures the manager cluster by the token. Called by the manager context.
+func (f fedmanctl) FederateWorkloadCluster(token, namespace string) error {
+	workerClusterInfo, err := DetokenizeWorkloadClusterInfo(token)
+
+	if err != nil {
+		return err
+	}
+
+	// Create the federated namespace
+	federationUID, err := f.getClusterUID()
+
+	if err != nil {
+		return err
+	}
+
+	// Check if federation namespace "federation-XXX-XXX-XX-XXXX" exists, if not create.
+	federationNamespaceName := fmt.Sprintf(federationv1alpha1.FederationManagerNamespace, federationUID)
+
+	_, err = f.GetKubeClientset().CoreV1().Namespaces().Get(context.TODO(), federationNamespaceName, v1.GetOptions{})
+	if err != nil {
+		ns := &corev1.Namespace{
+			ObjectMeta: v1.ObjectMeta{
+				Name: federationNamespaceName,
+			},
+		}
+		_, err = f.GetKubeClientset().CoreV1().Namespaces().Create(context.TODO(), ns, v1.CreateOptions{})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	// Check if the secret storage namespace exsits. If not create? No it is up to the user to create and give permissions.
+	_, err = f.GetKubeClientset().CoreV1().Namespaces().Get(context.TODO(), namespace, v1.GetOptions{})
+	if err != nil {
+		if err != nil {
+			return fmt.Errorf("cannot find given namespace, please ensure the namespace %q exist", namespace)
+		}
+	}
+
+	// secretName has the convention "secret-XXX" where XXX is the UID of the cluster
+	secretName := strings.Join([]string{"secret", workerClusterInfo.UID}, "-")
+
+	// clusterName has the convention "cluster-XXX" where XXX is the UID of the cluster
+	clusterName := strings.Join([]string{"cluster", workerClusterInfo.UID}, "-")
+
+	// Create the secret in the given namespace
+	secret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"ca.crt":    []byte(workerClusterInfo.CACertificate),
+			"token":     []byte(workerClusterInfo.Token),
+			"namespace": []byte(workerClusterInfo.Namespace),
+		},
+	}
+
+	_, err = f.GetKubeClientset().CoreV1().Secrets(namespace).Create(context.TODO(), secret, v1.CreateOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	// create the cluster in the given namespace
+	cluster := &federationv1alpha1.Cluster{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: namespace,
+			Labels:    workerClusterInfo.Labels,
+		},
+		Spec: federationv1alpha1.ClusterSpec{
+			UID:        workerClusterInfo.UID,
+			Role:       "Workload",
+			Server:     strings.Join([]string{workerClusterInfo.ClusterIP, workerClusterInfo.ClusterPort}, ":"),
+			Visibility: workerClusterInfo.Visibility,
+			Enabled:    true,
+			SecretName: secretName,
+			// For now we do not employ any referance mechanism
+		},
+	}
+
+	_, err = f.GetEdgeNetClientset().FederationV1alpha1().Clusters(namespace).Create(context.TODO(), cluster, v1.CreateOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Unlinks the worker cluster from manager cluster. Called by the manager context.
+func (f fedmanctl) UnfederateWorkloadCluster(uid, namespace string) error {
+	secretName := strings.Join([]string{"secret", uid}, "-")
+	clusterName := strings.Join([]string{"cluster", uid}, "-")
+
+	f.GetKubeClientset().CoreV1().Secrets(namespace).Delete(context.TODO(), secretName, v1.DeleteOptions{})
+	f.GetEdgeNetClientset().FederationV1alpha1().Clusters(namespace).Delete(context.TODO(), clusterName, v1.DeleteOptions{})
+
+	return nil
+}
+
+// List the worker cluster objects
+func (f fedmanctl) ListWorkloadClusters() ([]federationv1alpha1.Cluster, error) {
+	// Get all the cluster objects from all of the namespaces
+	clusters, err := f.GetEdgeNetClientset().FederationV1alpha1().Clusters("").List(context.TODO(), v1.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return clusters.Items, nil
+}
+
+func (f fedmanctl) Version() string {
+	return "v1.0.0"
+}
+
+// Get the current cluster's UID (kube-system uid)
+func (f fedmanctl) getClusterUID() (string, error) {
+	kubeNamespace, err := f.GetKubeClientset().CoreV1().Namespaces().Get(context.TODO(), "kube-system", v1.GetOptions{})
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(kubeNamespace.UID), nil
+}
+
+// Get the secret of the fedmanager
+func (f fedmanctl) getSecret() (*corev1.Secret, error) {
+	secret, err := f.GetKubeClientset().CoreV1().Secrets("edgenet").Get(context.TODO(), "fedmanager", v1.GetOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}

--- a/pkg/fedmanctl/fedmanctl.go
+++ b/pkg/fedmanctl/fedmanctl.go
@@ -41,7 +41,7 @@ type Fedmanctl interface {
 	FederateWorkloadCluster(token, namespace string) error
 
 	// Unlinks the worker cluster from manager cluster. Called by the manager context.
-	UnfederateWorkloadCluster(uid, namespace string) error
+	SeparateWorkloadCluster(uid, namespace string) error
 
 	// List the worker cluster objects
 	ListWorkloadClusters() ([]federationv1alpha1.Cluster, error)
@@ -346,7 +346,7 @@ func (f fedmanctl) FederateWorkloadCluster(token, namespace string) error {
 }
 
 // Unlinks the worker cluster from manager cluster. Called by the manager context.
-func (f fedmanctl) UnfederateWorkloadCluster(uid, namespace string) error {
+func (f fedmanctl) SeparateWorkloadCluster(uid, namespace string) error {
 	secretName := strings.Join([]string{"secret", uid}, "-")
 	clusterName := strings.Join([]string{"cluster", uid}, "-")
 

--- a/pkg/fedmanctl/token.go
+++ b/pkg/fedmanctl/token.go
@@ -1,0 +1,69 @@
+package fedmanctl
+
+import (
+	b64 "encoding/base64"
+	"encoding/json"
+)
+
+// Contains information about the federation. Do not share this token,
+// it contians sensitive information.
+type WorkloadClusterInfo struct {
+	// These 3 fields are gathered from the secret created on worker cluster
+	CACertificate string `json:"ca.crt"`
+	Namespace     string `json:"namespace"`
+	Token         string `json:"token"`
+
+	// UID of the kube-system namespace
+	UID string `json:"uid"`
+
+	// Cluster IP/Port information
+	ClusterIP   string `json:"clusterIP"`
+	ClusterPort string `json:"clusterPort"`
+
+	// Can be "Public" or "Private"
+	Visibility string `json:"visibility"`
+
+	// Labels of the cluster
+	Labels map[string]string `json:"labels"`
+}
+
+// Converts the WorkloadClusterInfo object to a base64 encoded string
+func TokenizeWorkloadClusterInfo(w *WorkloadClusterInfo) (string, error) {
+	// Remove empty labels to reduce token size
+	strippedLabels := make(map[string]string, len(w.Labels))
+
+	for label, value := range w.Labels {
+		if value != "" {
+			strippedLabels[label] = value
+		}
+	}
+
+	w.Labels = strippedLabels
+
+	src, err := json.Marshal(w)
+
+	if err != nil {
+		return "", err
+	}
+
+	return b64.StdEncoding.EncodeToString(src), nil
+}
+
+// Retrieves the WorkloadClusterInfo object from the base64 encoded token
+func DetokenizeWorkloadClusterInfo(token string) (*WorkloadClusterInfo, error) {
+	src, err := b64.StdEncoding.DecodeString(token)
+
+	if err != nil {
+		return nil, err
+	}
+
+	w := &WorkloadClusterInfo{}
+
+	err = json.Unmarshal(src, w)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}


### PR DESCRIPTION
## Before you read;
This PR is essentially a copy of #180 which was merged to `main` and quickly reverted. I am opening this PR again. It contains all the changes as in #180 plus the latest renaming. The tutorial is also adjusted.

## What This Patch Does?
In this patch I implemented a CLI named fedmanctl. It aims to automate cluster federation. I will also submit another patch for the documentation, tutorial, and installation guide.

## Changes
Additionally, I changed the federation.yaml files. Divided them into two named `federation-manager.yaml` and `federation-workload.yaml`. 

## Next Steps
I will also update the documentation on the [ufukbombar-docs](https://github.com/EdgeNet-project/edgenet/tree/ufukbombar-docs) branch.

## Testing
For testing, I created 3 minikube clusters using the docker driver and make sure they are located in the same network (--network="bridge"). Then followed the regular installation tutorial for `location-based-selective-deployment`, `multi-tenancy` and corresponding `federation` features. Federation cluster received the `federation-manager` features and 2 other worker clusters received `federation-workload` features. 

## Exapmles
I designed the command structure with the following comments:

```bash
# I need to specify the context so I don't have to set the default context on the kubeconfig each time.
# This initialized the workload cluster
fedmanctl workload init --context <WORKLOAD1>
fedmanctl workload init --context <WORKLOAD2>

# Generates the token with additional labels such as the public ip, port, and edgenet annotations.
# With the silent option, the comand will only generate the token.
fedmanctl workload token --city <CITY1> --country <COUNTRY2> --ip <IPADDRESS> --port <PORT> --silent --context <WORKLOAD1>
fedmanctl workload token --city <CITY2> --country <COUNTRY2> --ip <IPADDRESS> --port <PORT> --silent --context <WORKLOAD2>

# Now using the token link it to the federation cluster
fedmanctl manager federate <TOKEN1> <SECRET's NAMESPACE> --context <MANAGER>
fedmanctl manager federate <TOKEN2> <SECRET's NAMESPACE> --context <MANAGER>

# You can also list the federated clusters
fedmanctl manager list --context <MANAGER>

# Then if you want to unfederate/separate, paste the uid of the cluster and the namespace info
fedmanctl manager separate <UID> <SECRET's NAMESPACE> --context <MANAGER>

# To remove federation secrets from the working cluster
fedmanctl workload reset --context <WORKLOAD1>
fedmanctl workload reset --context <WORKLOAD2>
```